### PR TITLE
Update 7.6 alias

### DIFF
--- a/products.yml
+++ b/products.yml
@@ -22,8 +22,8 @@ couchbase-server:
     release:  '7.2.8-8929'
     stable:   '7.2.9-9157'
   '7.6':
-    release:  '7.6.7-6710'
-    stable:   '7.6.8-7144'
+    release:  '7.6.11'
+    stable:   '7.6.11'
   '8.0':
     release:  '8.0.0'
     stable:   '8.0.0-3777'


### PR DESCRIPTION
libcouchbase TLS/Views tests failing on older versions. See: https://review.couchbase.org/c/libcouchbase/+/244163